### PR TITLE
Fix 404 pages

### DIFF
--- a/content/posts/2018-06-20-loopback4-improves-inbound-http-processing.md
+++ b/content/posts/2018-06-20-loopback4-improves-inbound-http-processing.md
@@ -18,10 +18,10 @@ is battle-tested by years of production use.
 While discussing the new direction, we thought it would be great to support
 multiple different HTTP frameworks like Express and Koa and implement a thin
 integration layer to allow mounting of LoopBack 4 REST router.
-[Raymond](/authors/Raymond_Feng/) researched this approach in a spike pull
-request [#1082](https://github.com/strongloop/loopback-next/pull/1082). Later
-on, [Yaapa](/authors/Hage_Yaapa/) looked into practical implications of the
-proposed approach and discovered that Express and Koa are fundamentally
+[Raymond](https://github.com/raymondfeng) researched this approach in a spike
+pull request [#1082](https://github.com/strongloop/loopback-next/pull/1082).
+Later on, [Yaapa](https://github.com/hacksparrow) looked into practical implications of
+the proposed approach and discovered that Express and Koa are fundamentally
 incompatible at such level that it's impossible to write a a single
 middleware/route function that would work with both frameworks. That left us
 with a difficult decision to make: going forward, should we pick Express or Koa

--- a/content/posts/2022-01-privacy-friendly-web-analytics.md
+++ b/content/posts/2022-01-privacy-friendly-web-analytics.md
@@ -39,8 +39,7 @@ implemented tracking:
    own domain: [/s/main.js](/s/main.js). Under the hood, Netlify handles this
    endpoint by fetching the response from Plausible.
 2. I configured the Plausible client to post events to an URL on my own domain
-   too: [/s/event](/s/event). This endpoint is again proxied by Netlify to
-   Plausible.
+   too: `/s/event`. This endpoint is again proxied by Netlify to Plausible.
 3. Finally, I have a small script to detect Netlify preview domains and tell the
    Plausible client to report a different domain name to the data collector.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -52,7 +52,17 @@ HUGO_VERSION = "0.78.2"
   status = 302
 
 [[redirects]]
+  from = "/2018-QuantumIntro"
+  to = "/gh/2019-QuantumIntro"
+  status = 302
+
+[[redirects]]
   from = "/T"
+  to = "/gh/2018-AsyncAwait"
+  status = 302
+
+[[redirects]]
+  from = "/2018-AsyncAwait"
   to = "/gh/2018-AsyncAwait"
   status = 302
 


### PR DESCRIPTION
- `/s/event` is a POST-only endpoint, change the reference in a blog
  post from `<a href>` to `<code>`.

- Add redirects for old stuff: `/2018-QuantumIntro`, `/2018-AsyncAwait`

- Rework links to LoopBack colleagues to point to their GitHub profiles
